### PR TITLE
Enable 'code' param to be sent to Mock SSO

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,21 @@ def index():
 
 Done.
 
+# Use with UKTrade mock-sso package
+
+It is possible to configure this package to work with the [mock-sso service](https://github.com/uktrade/mock-sso).
+
+Mock SSO requires that you provide a non-standard parameter in the query string of the initial GET call of the OAuth flow. (See the [mock-sso docs](https://github.com/uktrade/mock-sso/blob/master/README.md) for more detail.)
+
+This parameter is called `code`. Any services which use THIS library (flask-authbroker-client) could need to undertake automated tests of a stack which uses Staff SSO.
+
+For circumstances like these you will need to prime mock-sso with this `code` parameter.
+
+This is achieved by changing the Flask config for the app which is importing THIS library. You'd achieve this by adding
+a line like the following to the "app config" code example in the [Usage section](#usage) above.
+```
+app.config['ABC_TEST_SSO_RETURN_ACCESS_TOKEN'] = 'someCode'
+```
+where 'someCode' will then be provided as the `code` param when the user agent is redirected to mock-sso, and in turn
+the same 'someCode' value will be present as the `access_token` in the redirect back to your app from mock.sso. (Again,
+see the [mock-sso docs](https://github.com/uktrade/mock-sso/blob/master/README.md) for more detail.)

--- a/authbroker_client.py
+++ b/authbroker_client.py
@@ -29,7 +29,16 @@ def _get_client():
     global authbroker_client, get_token
 
     if not authbroker_client:
-        base_url = current_app.config['ABC_BASE_URL']
+        conf = current_app.config
+
+        base_url = conf['ABC_BASE_URL']
+
+        request_token_params = {
+            'state': lambda: security.gen_salt(10)
+        }
+        test_sso_return_token = conf.get('ABC_TEST_SSO_RETURN_ACCESS_TOKEN')
+        if test_sso_return_token:
+            request_token_params['code'] = test_sso_return_token
 
         authbroker_client = oauth.remote_app(
             'authbroker',
@@ -37,12 +46,10 @@ def _get_client():
             request_token_url=None,
             access_token_url=urljoin(base_url, '/o/token/'),
             authorize_url=urljoin(base_url, '/o/authorize/'),
-            consumer_key=current_app.config['ABC_CLIENT_ID'],
-            consumer_secret=current_app.config['ABC_CLIENT_SECRET'],
+            consumer_key=conf['ABC_CLIENT_ID'],
+            consumer_secret=conf['ABC_CLIENT_SECRET'],
             access_token_method='POST',
-            request_token_params={
-                'state': lambda: security.gen_salt(10)
-            }
+            request_token_params=request_token_params,
         )
 
         get_token = authbroker_client.tokengetter(get_token)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from distutils.core import setup
 
 setup(name='flask-authbroker-client',
-      version='0.1',
+      version='0.2',
       description='A blueprint to integrate with the DIT Authbroker client',
       author='Lyndon Garvey',
       author_email='lyndon.garvey@digital.trade.gov.uk',


### PR DESCRIPTION
If your Flask app wants to operate with Mock SSO (e.g. for dev purposes or to enable e2e testing) then this lib will need to play ball with mock-sso and provide a `code` param as part of the query string in the redirect.

This PR enables that.