### PR TITLE
adds backwards-compatible import to support authlib

### DIFF
--- a/authbroker_client.py
+++ b/authbroker_client.py
@@ -4,7 +4,16 @@ from urllib.parse import urljoin, urlparse
 
 from werkzeug import security
 from flask import Blueprint, redirect, url_for, session, request, current_app
-from flask_oauthlib.client import OAuth
+
+# ATTENTION: Flask-OAuthLib is deprecated
+# Authlib (https://github.com/lepture/authlib) should be used instead
+# this is a fallback import to allow existing projects time to update Flask/Werkzeug
+try:
+    # old versions, backwards compatible
+    from flask_oauthlib.client import OAuth
+except ImportError:
+    # newer projects
+    from authlib.integrations.flask_client import OAuth
 
 
 __all__ = ('authbroker_blueprint', 'NotAuthenticatedError', 'login_required',

--- a/authbroker_client.py
+++ b/authbroker_client.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from functools import wraps
 from urllib.parse import urljoin, urlparse
 
@@ -7,13 +8,13 @@ from flask import Blueprint, redirect, url_for, session, request, current_app
 
 # ATTENTION: Flask-OAuthLib is deprecated
 # Authlib (https://github.com/lepture/authlib) should be used instead
-# this is a fallback import to allow existing projects time to update Flask/Werkzeug
 try:
-    # old versions, backwards compatible
-    from flask_oauthlib.client import OAuth
-except ImportError:
     # newer projects
     from authlib.integrations.flask_client import OAuth
+except ImportError:
+    # this is a fallback import to allow existing projects time to update Flask/Werkzeug
+    warnings.warn("deprecated", DeprecationWarning)
+    from flask_oauthlib.client import OAuth
 
 
 __all__ = ('authbroker_blueprint', 'NotAuthenticatedError', 'login_required',


### PR DESCRIPTION
This PR allows the use of https://github.com/lepture/authlib as it's the recommended action after the [deprecation of `Flask-OAuthLib`](https://flask-oauthlib.readthedocs.io/en/latest/)

It's backwards compatible, so that other projects using this client have time to update their requirements